### PR TITLE
A couple fixes and tweaks

### DIFF
--- a/Vagrantfile.template
+++ b/Vagrantfile.template
@@ -20,11 +20,11 @@ Vagrant.configure("2") do |config|
  
     config.vm.define "server" do |server|
         config.vm.provider :rackspace do |server|
-            server.server_name = "--RS-SERVER--"
+            server.server_name = "vagrant_--RS-SERVER--"
             server.username = RS_USER
             server.api_key = RS_KEY
-            server.flavor = /1GB/
-            server.image = /^--RS-FLAVOR--$/
+            server.flavor = /1 GB/
+            server.image = /^--RS-IMAGE--$/
             server.rackspace_region = RS_REGION
             server.public_key_path = PUBLIC_KEY
             #server.network RS_NETWORK

--- a/mkdir_vagrant_structure.rb
+++ b/mkdir_vagrant_structure.rb
@@ -60,9 +60,9 @@ image_list['images'].each do |image|
       system 'mkdir', '-p' , dirname
 
       # Read in the template file
-      tmp_file = File.read('Vagrantfile.template')
+      tmp_file = File.read(File.expand_path('../Vagrantfile.template', __FILE__))
 
       # Write the Vagrantfile out in to the proper directory 
-      File.open( dirname + '/Vagrantfile' , 'w') { |file| file.puts tmp_file.gsub(/--RS-FLAVOR--/, imagename ).gsub(/--RS-SERVER--/ , dirname) }
+      File.open( dirname + '/Vagrantfile' , 'w') { |file| file.puts tmp_file.gsub(/--RS-IMAGE--/, imagename ).gsub(/--RS-SERVER--/ , dirname) }
    end
 end


### PR DESCRIPTION
- Prefix cloud machine names with 'vagrant_' to distinguish them from other cloud servers on account
- Change flavor match to /1 GB/, to change from the '1GB Standard Instance' match to the new '1 GB General Purpose v1' flavor
- Rename Regex replacement for server.image from --RS-FLAVOR-- to more appropriate --RS-IMAGE--
- Allow script to run from directories other than the script's directory, by finding the absolute path for Vagrantfile.template
