### PR TITLE
Add cleanup loop to prune unused boxes based on unavailable images

### DIFF
--- a/mkdir_vagrant_structure.rb
+++ b/mkdir_vagrant_structure.rb
@@ -9,8 +9,10 @@ rescue LoadError => fog_error
    raise
 end
 
+require 'csv'  # Needed to parse the vagrant --machine-readable output
 require 'yaml' # Needed to read in the configuration file
 require 'json' # Needed to parse through the Fog::compute response
+require 'fileutils' # Needed to be smarter about interacting with dirs
 
 # Setup Rackspace variables
 RS_CONFIG = YAML.load_file(ENV['HOME'] + '/.rax_cred_file') #Looks for a credential file in the user's home directory
@@ -38,6 +40,7 @@ image_list = response.body
 # Setup the list of excludes
 images_excluded = ['Windows','iPXE','Vyatta']
 image_hash = Hash.new()
+dirnames = Array.new()
 
 # Going through all of the images and only print those not on the exclude list
 image_list['images'].each do |image| 
@@ -52,17 +55,36 @@ image_list['images'].each do |image|
    if print_image 
       dirname = image['name'].downcase.tr(" ","_").tr("(","").tr(")","") # Created the directory by replacing spaces with _ and removing parenthesis
       imagename = image['name'].tr('(',".*").tr(')',".*") # Replace open/close parenthesis with . so the image name can be matched directly
+      dirnames.push dirname
 
       # Note: I could not for the life of me figure out how to get a "\(" or "\)" to be printed on the damn screen.
       # I opted to just replace it with a . so that it maches any single character
 
       # Create the directories as needed
-      system 'mkdir', '-p' , dirname
+      FileUtils.mkdir_p dirname
 
       # Read in the template file
       tmp_file = File.read(File.expand_path('../Vagrantfile.template', __FILE__))
 
       # Write the Vagrantfile out in to the proper directory 
       File.open( dirname + '/Vagrantfile' , 'w') { |file| file.puts tmp_file.gsub(/--RS-IMAGE--/, imagename ).gsub(/--RS-SERVER--/ , dirname) }
+   end
+end
+
+# Cleanup old unused directories
+basedir = Dir.pwd
+
+Dir.foreach(basedir) do |dir|
+   # Ignore current and parent directorires, and any that we just created, or symlinks
+   next if dir == '.' or dir == '..' or dirnames.include?(dir) or File.symlink?(dir)
+
+   # cd into the vagrant machine directory and get it's status
+   FileUtils.chdir dir
+   csvoutput = CSV.parse `vagrant status --machine-readable 2>&1`
+
+   # Get back to the parent directory so we can remove the dir if needed and continue
+   FileUtils.chdir basedir
+   if csvoutput[1][3] == 'not_created'
+      FileUtils.rm_rf dir
    end
 end


### PR DESCRIPTION
This PR primarily adds a loop at the end that goes through any directories in the current directory and removes any that rely on images that are not available. It ignores any directories that we just created, and since I have my ssh-keys symlinked in the same directory, it ignores symlinks as well.

As a side benefit, it also changes the 'mkdir -p' system call to the native ruby FileUtils.mkdir_p function, which does the same thing.